### PR TITLE
Add KraftKit configuration file for KraftCloud

### DIFF
--- a/kraft.cloud.yaml
+++ b/kraft.cloud.yaml
@@ -1,0 +1,49 @@
+---
+specification: '0.5'
+name: nginx
+unikraft:
+  version: cloud
+  kconfig:
+    - CONFIG_LIBUKLIBPARAM=y
+    - CONFIG_LIBUKSCHEDCOOP=y
+    - CONFIG_LIBPOSIX_LIBDL=y
+    - CONFIG_LIBPOSIX_PROCESS=y
+    - CONFIG_LIBPOSIX_USER=y
+    - CONFIG_UKSYSINFO=y
+    - CONFIG_LIBUKSIGNAL=y
+    - CONFIG_LIBPOSIX_MMAP=y
+    - CONFIG_LIBUKTIME=y
+targets:
+  - name: kraftcloud-x86_64
+    architecture: x86_64
+    platform: firecracker
+    kconfig:
+      - CONFIG_PLAT_KVM=y
+      - CONFIG_KVM_BOOT_PROTO_LXBOOT=y
+      - CONFIG_KVM_VMM_FIRECRACKER=y
+      - CONFIG_LIBVFSCORE_AUTOMOUNT_ROOTFS=y
+      - CONFIG_LIBVFSCORE_ROOTFS_INITRD=y
+      - CONFIG_LIBVFSCORE_ROOTFS="initrd"
+      - CONFIG_VIRTIO_BUS=y
+libraries:
+  musl:
+    version: stable
+  lwip:
+    version: stable
+    kconfig:
+      - CONFIG_LWIP_UKNETDEV=y
+      - CONFIG_LWIP_TCP=y
+      - CONFIG_LWIP_WND_SCALE=y
+      - CONFIG_LWIP_TCP_KEEPALIVE=y
+      - CONFIG_LWIP_THREADS=y
+      - CONFIG_LWIP_SOCKET=y
+      - CONFIG_LWIP_AUTOIFACE=y
+      - CONFIG_LWIP_IPV4=y
+      - CONFIG_LWIP_DNS=y
+  nginx:
+    version: stable
+    kconfig:
+      - CONFIG_LIBNGINX_MAIN_FUNCTION=y
+  ukp-bin:
+    source: https://github.com/unikraft-io/lib-ukp-bin
+    version: stable


### PR DESCRIPTION
Add `kraft.cloud.yaml` configuration file to build and run for KraftCloud.

Build with:

```console
kraft build --kraftfile kraft.cloud.yaml -j $(nproc)
```

Run with:

```console
sudo kraft net create -n 172.44.0.1/24 kraft0
sudo kraft run --kraftfile kraft.cloud.yaml --network bridge:kraft0 --plat firecracker --initrd ./fs0 -a netdev.ipv4_addr=172.44.0.2 -a netdev.ipv4_gw_addr=172.44.0.1 -a netdev.ipv4_subnet_mask=255.255.255.0 -- -c /nginx/conf/nginx.conf
```