### PR TITLE
Disable access logs in example config

### DIFF
--- a/rootfs/nginx/conf/nginx.conf
+++ b/rootfs/nginx/conf/nginx.conf
@@ -14,6 +14,8 @@ http {
 
   keepalive_timeout 65;
 
+  access_log off;
+
   server {
     listen 80;
     server_name localhost;


### PR DESCRIPTION
Usually the access log is placed in RAM, therefore slowly filling up the available memory with access logs. The usefulness of access logs in this configuration is very limited because there is no way to access them anyway.